### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you have questions please contact us at support@loopmemedia.com.
 
 An appKey is required to use the `loopme-ios-sdk`. The appKey uniquely identifies your app to the LoopMe ad network. (Example appKey: 7643ba4d53.) To get an appKey visit the **[LoopMe Dashboard](http://loopme.me/)**.
 
-Requires `XCode 7` or higher, `iOS 8.0` and above. Built using `ARC`.
+Requires `Xcode 7` or higher, `iOS 8.0` and above. Built using `ARC`.
 
 ## Integration ##
 


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
